### PR TITLE
Implement HTML to ANSI convertation

### DIFF
--- a/MarkdownConverter.Tests.cs
+++ b/MarkdownConverter.Tests.cs
@@ -63,5 +63,72 @@ namespace MarkdownConverter
 
             Assert.Throws<InvalidMarkdownException>(() => MarkdownConverter.ToHtml(invalidMarkdown));
         }
+
+
+        [Fact]
+        public void TestToAnsi_ConvertsBoldCorrectly()
+        {
+            string markdown = "**bold ** text**";
+            string expected = "\u001b[1mbold ** text\u001b[22m";
+
+            string actual = MarkdownConverter.ToAnsi(markdown);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestToAnsi_ConvertsItalicCorrectly()
+        {
+            string markdown = "_italic _ text_";
+            string expected = "\u001b[3mitalic _ text\u001b[23m";
+
+            string actual = MarkdownConverter.ToAnsi(markdown);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestToAnsi_ConvertsCodeCorrectly()
+        {
+            string markdown = "`code ` text`";
+            string expected = "\u001b[7mcode ` text\u001b[27m";
+
+            string actual = MarkdownConverter.ToAnsi(markdown);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestToAnsi_ConvertsPreformattedCorrectly()
+        {
+            string markdown = "```preformatted_ **text\n\n\n `for` check```";
+            string expected = "\u001b[7mpreformatted_ **text\n\n\n `for` check\u001b[27m";
+
+            string actual = MarkdownConverter.ToAnsi(markdown);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TestToSpecifiedFormat_ThrowsArgumentExceptionOnFormat()
+        {
+            string markdown = "text";
+            string invalidFormat = "invalid format";
+
+            Assert.Throws<ArgumentException>(() => MarkdownConverter.ToSpecifiedFormat(invalidFormat, markdown));
+        }
+
+        [Fact]
+        public void TestToSpecifiedFormat_SelectCorrectFormat()
+        {
+            string markdown = "**bold** text for _test_";
+            string expectedAnsi = "\u001b[1mbold\u001b[22m text for \u001b[3mtest\u001b[23m";
+            string expectedHtml = "<p><b>bold</b> text for <i>test</i></p>";
+
+            string actualAnsi = MarkdownConverter.ToSpecifiedFormat("ansi", markdown);
+            string actualHtml = MarkdownConverter.ToSpecifiedFormat("html", markdown);
+            Assert.Equal(expectedAnsi, actualAnsi);
+            Assert.Equal(expectedHtml, actualHtml);
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -4,31 +4,39 @@
     {
         static void Main(string[] args)
         {
-            if (args.Length == 0) throw new Exception("any args was passed");
+            if (args.Length == 0) throw new ArgumentNullException("any args was passed");
 
             string readingFilePath = args[0];
-            string outFilePath = String.Empty;
-            if (!File.Exists(readingFilePath)) throw new Exception("incorrect reading file path was passed");
+            if (!File.Exists(readingFilePath)) throw new ArgumentException("incorrect reading file path was passed");
 
-            string fileContent = File.ReadAllText(readingFilePath);
-            string html = MarkdownConverter.ToHtml(fileContent);
+            string outFilePath = String.Empty;
+            string format = String.Empty;
 
             for (int i = 0; i < args.Length; i++)
             {
                 if (args[i] == "--out" && i + 1 < args.Length)
                 {
                     outFilePath = args[i + 1];
-                    break;
+                }
+                if (args[i] == "--format" && i + 1 < args.Length)
+                {
+                    format = args[i + 1];
                 }
             }
 
-            if (outFilePath == null)
+            string fileContent = File.ReadAllText(readingFilePath);
+
+
+            if (String.IsNullOrEmpty(outFilePath))
             {
-                Console.WriteLine(html);
+                Console.WriteLine(
+                    MarkdownConverter.ToSpecifiedFormat(String.IsNullOrEmpty(format) ? "ansi" : format, fileContent));
             }
             else
             {
-                File.WriteAllText(outFilePath, html);
+                File.WriteAllText(
+                    outFilePath,
+                    MarkdownConverter.ToSpecifiedFormat(String.IsNullOrEmpty(format) ? "html" : format, fileContent));
             }
         }
     }


### PR DESCRIPTION
- updated exceptions in main startup method to specify type of error
- changed logic for selecting convertation method in Main method
- created ToSpecifiedFormat method in MarkdownConverter to implement selecting logic in Main method
- created ToAnsi method in MarkdownConverter to convert html to ansi
- moved general dictionaries and lists from MarkdownConverter methods to class readonly poles
- changed PartToHtml to ConvertPart method for universal using in both ToHtml and ToAnsi mthods by passing converting tags dictionary
- created _markdownlToAnsiDict and _markdownlToHtmlDict for use in ConvertPart method
- created unit tests for ToAnsi method
- created unit test for ToSpecifiedFormat method